### PR TITLE
Failed screenshot functionality

### DIFF
--- a/features/faker.feature
+++ b/features/faker.feature
@@ -4,6 +4,7 @@ Feature: Using Faker to generate dynamic data
   I want to input data using Faker
   So that I can enter dynamic randomized data when signing up
 
+  @failing
   Scenario: Generate an email address from Faker and submit the form
     Given the user goes to the Internet's Forgot Password page
     When the user submits a dynamic email with Faker

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -49,7 +49,12 @@ Before('@japanese_locale') do
   Faker::Config.locale = 'ja'
 end
 
-After('@chrome') do
+After('@chrome') do |scenario|
+  if scenario.failed?
+    # Put the screenshot in the folder
+    screenshot = "./reports/failures/#{scenario.name.gsub(' ','_').gsub(/[^0-9A-Za-z_]/, '')}_#{Time.now}.png"
+    @browser.driver.save_screenshot(screenshot)
+  end
   @browser.quit
 end
 

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -49,15 +49,22 @@ Before('@japanese_locale') do
   Faker::Config.locale = 'ja'
 end
 
-After('@chrome') do |scenario|
-  if scenario.failed?
-    # Put the screenshot in the folder
-    screenshot = "./reports/failures/#{scenario.name.gsub(' ','_').gsub(/[^0-9A-Za-z_]/, '')}_#{Time.now}.png"
-    @browser.driver.save_screenshot(screenshot)
-  end
+After('@chrome') do
   @browser.quit
 end
 
 After('@headless') do
   @browser.quit
+end
+
+After do |scenario|
+  if scenario.failed?
+    # Create the directory if it doesn't exist and delete any
+    # previous .png files in the directory
+    Dir.mkdir('./reports/failures') unless File.exist?('./reports/failures')
+    Dir.glob('./reports/failures/*').select { |file| /png/.match file }.each { |file| File.delete(file) }
+    # Put the screenshot of the failed test in the folder
+    screenshot = "./reports/failures/#{scenario.name.gsub(' ','_').gsub(/[^0-9A-Za-z_]/, '')}_#{Time.now}.png"
+    @browser.driver.save_screenshot(screenshot)
+  end
 end


### PR DESCRIPTION
Adds an after hook that creates a failures directory, deletes any previous failures, and creates a timestamped PNG file that is created in the event that a test scenario fails.